### PR TITLE
rename github.com/go-resty/resty to gopkg.in/resty.v1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,14 +18,6 @@
   revision = "325932fa68e70dd4464598f11e2f710ac1aaec46"
 
 [[projects]]
-  digest = "1:3a000b3680bc855754c9e9a10158315aff3a0c2a463a8987bc5ae221bc7c6318"
-  name = "github.com/go-resty/resty"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9ac9c42358f7c3c69ac9f8610e8790d7c338e85d"
-  version = "v1.0"
-
-[[projects]]
   branch = "master"
   digest = "1:9b0e71863f18fc5de645a263184c8a6409ae731e847b35b25da4be818f1975fa"
   name = "github.com/golang/protobuf"
@@ -125,13 +117,21 @@
   pruneopts = "UT"
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
+[[projects]]
+  digest = "1:41206f4d0410803e64cfb203f665330c3183988408cb532b56305a816a87bd99"
+  name = "gopkg.in/resty.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fa5875c0caa5c260ab78acec5a244215a730247f"
+  version = "v1.12.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/giantswarm/microerror",
-    "github.com/go-resty/resty",
     "github.com/prometheus/client_golang/prometheus",
+    "gopkg.in/resty.v1",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  name = "github.com/go-resty/resty"
+  name = "gopkg.in/resty.v1"
   version = "1.0.0"
 
 [[constraint]]

--- a/microclient.go
+++ b/microclient.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/go-resty/resty"
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/resty.v1"
 
 	"github.com/giantswarm/microerror"
 )

--- a/vendor/github.com/go-resty/resty/resty.go
+++ b/vendor/github.com/go-resty/resty/resty.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
-// resty source code and usage is governed by a MIT style
-// license that can be found in the LICENSE file.
-
-// Package resty provides simple HTTP and REST client for Go inspired by Ruby rest-client.
-package resty
-
-// Version # of resty
-const Version = "1.0"

--- a/vendor/gopkg.in/resty.v1/.gitignore
+++ b/vendor/gopkg.in/resty.v1/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 coverage.out
+coverage.txt
+go.sum

--- a/vendor/gopkg.in/resty.v1/.travis.yml
+++ b/vendor/gopkg.in/resty.v1/.travis.yml
@@ -2,18 +2,16 @@ language: go
 
 sudo: false
 
-# branches:
-#   only:
-#     - master
-#     - integration
-
 go:
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
+#  - 1.3
+#  - 1.4
+#  - 1.5
+#  - 1.6
+#  - 1.7
+#  - 1.8.x
+#  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 install:

--- a/vendor/gopkg.in/resty.v1/BUILD.bazel
+++ b/vendor/gopkg.in/resty.v1/BUILD.bazel
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:private"])
+
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+gazelle(
+    name = "gazelle",
+    command = "fix",
+    prefix = "gopkg.in/resty.v1",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
+    importpath = "gopkg.in/resty.v1",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_net//publicsuffix:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs =
+        glob(
+            ["*_test.go"],
+            exclude = ["example_test.go"],
+        ),
+    data = glob([".testdata/*"]),
+    embed = [":go_default_library"],
+    importpath = "gopkg.in/resty.v1",
+    deps = [
+        "@org_golang_x_net//proxy:go_default_library",
+    ],
+)

--- a/vendor/gopkg.in/resty.v1/LICENSE
+++ b/vendor/gopkg.in/resty.v1/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
+Copyright (c) 2015-2019 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/gopkg.in/resty.v1/README.md
+++ b/vendor/gopkg.in/resty.v1/README.md
@@ -1,43 +1,57 @@
-# Resty  [![Build Status](https://travis-ci.org/go-resty/resty.svg?branch=master)](https://travis-ci.org/go-resty/resty) [![codecov](https://codecov.io/gh/go-resty/resty/branch/master/graph/badge.svg)](https://codecov.io/gh/go-resty/resty/branch/master)  [![GoReport](https://goreportcard.com/badge/go-resty/resty)](https://goreportcard.com/report/go-resty/resty)  [![Version](https://img.shields.io/badge/version-1.0-blue.svg)](https://github.com/go-resty/resty/releases/latest)  [![GoDoc](https://godoc.org/github.com/go-resty/resty?status.svg)](https://godoc.org/github.com/go-resty/resty) [![License](https://img.shields.io/github/license/go-resty/resty.svg)](LICENSE)
+<p align="center">
+<h1 align="center">Resty</h1>
+<p align="center">Simple HTTP and REST client library for Go (inspired by Ruby rest-client)</p>
+<p align="center"><a href="#features">Features</a> section describes in detail about Resty capabilities</p>
+</p>
+<p align="center">
+<p align="center"><a href="https://travis-ci.org/go-resty/resty"><img src="https://travis-ci.org/go-resty/resty.svg?branch=master" alt="Build Status"></a> <a href="https://codecov.io/gh/go-resty/resty/branch/master"><img src="https://codecov.io/gh/go-resty/resty/branch/master/graph/badge.svg" alt="Code Coverage"></a> <a href="https://goreportcard.com/report/go-resty/resty"><img src="https://goreportcard.com/badge/go-resty/resty" alt="Go Report Card"></a> <a href="https://github.com/go-resty/resty/releases/latest"><img src="https://img.shields.io/badge/version-1.12.0-blue.svg" alt="Release Version"></a> <a href="https://godoc.org/gopkg.in/resty.v1"><img src="https://godoc.org/gopkg.in/resty.v1?status.svg" alt="GoDoc"></a> <a href="LICENSE"><img src="https://img.shields.io/github/license/go-resty/resty.svg" alt="License"></a></p>
+</p>
+<p align="center">
+<h4 align="center">Resty Communication Channels</h4>
+<p align="center"><a href="https://gitter.im/go_resty/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://badges.gitter.im/go_resty/community.svg" alt="Chat on Gitter - Resty Community"></a> <a href="https://twitter.com/go_resty"><img src="https://img.shields.io/badge/twitter-@go_resty-55acee.svg" alt="Twitter @go_resty"></a></p>
+</p>
 
-Simple HTTP and REST client for Go inspired by Ruby rest-client. [Features](#features) section describes in detail about Resty capabilities.
+## News
 
-***v1.0 [released](https://github.com/go-resty/resty/releases/latest) and tagged on Sep 25, 2017.***
+  * Resty `v2` development is in-progress :smile:
+  * v1.12.0 [released](https://github.com/go-resty/resty/releases/tag/v1.12.0) and tagged on Feb 27, 2019.
+  * v1.11.0 [released](https://github.com/go-resty/resty/releases/tag/v1.11.0) and tagged on Jan 06, 2019.
+  * v1.10.3 [released](https://github.com/go-resty/resty/releases/tag/v1.10.3) and tagged on Dec 04, 2018.
+  * v1.0 released and tagged on Sep 25, 2017. - Resty's first version was released on Sep 15, 2015 then it grew gradually as a very handy and helpful library. Its been a two years since first release. I'm very thankful to Resty users and its [contributors](https://github.com/go-resty/resty/graphs/contributors).
 
-*Since Go v1.6 HTTP/2 & HTTP/1.1 protocol is used transparently. `Resty` works fine with HTTP/2 and HTTP/1.1.*
+## Features
 
-#### v1.0 Released
-
-Resty first version released on Sep 15, 2015 then it grew gradually as a very handy and helpful library. Its been a two years; `v1.0` released on Sep 25, 2017. I'm very thankful to Resty users and its [contributors](https://github.com/go-resty/resty/graphs/contributors).
-
-#### Features
-  * GET, POST, PUT, DELETE, HEAD, PATCH and OPTIONS
+  * GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS, etc.
   * Simple and chainable methods for settings and request
   * Request Body can be `string`, `[]byte`, `struct`, `map`, `slice` and `io.Reader` too
     * Auto detects `Content-Type`
-  * [Response](https://godoc.org/github.com/go-resty/resty#Response) object gives you more possibility
+    * Buffer less processing for `io.Reader`
+  * [Response](https://godoc.org/gopkg.in/resty.v1#Response) object gives you more possibility
     * Access as `[]byte` array - `response.Body()` OR Access as `string` - `response.String()`
     * Know your `response.Time()` and when we `response.ReceivedAt()`
   * Automatic marshal and unmarshal for `JSON` and `XML` content type
     * Default is `JSON`, if you supply `struct/map` without header `Content-Type`
     * For auto-unmarshal, refer to -
-        - Success scenario [Request.SetResult()](https://godoc.org/github.com/go-resty/resty#Request.SetResult) and [Response.Result()](https://godoc.org/github.com/go-resty/resty#Response.Result).
-        - Error scenario [Request.SetError()](https://godoc.org/github.com/go-resty/resty#Request.SetError) and [Response.Error()](https://godoc.org/github.com/go-resty/resty#Response.Error).
+        - Success scenario [Request.SetResult()](https://godoc.org/gopkg.in/resty.v1#Request.SetResult) and [Response.Result()](https://godoc.org/gopkg.in/resty.v1#Response.Result).
+        - Error scenario [Request.SetError()](https://godoc.org/gopkg.in/resty.v1#Request.SetError) and [Response.Error()](https://godoc.org/gopkg.in/resty.v1#Response.Error).
+        - Supports [RFC7807](https://tools.ietf.org/html/rfc7807) - `application/problem+json` & `application/problem+xml`
   * Easy to upload one or more file(s) via `multipart/form-data`
+    * Auto detects file content type
+  * Request URL [Path Params (aka URI Params)](https://godoc.org/gopkg.in/resty.v1#Request.SetPathParams)
   * Backoff Retry Mechanism with retry condition function [reference](retry_test.go)
-  * resty client HTTP & REST [Request](https://godoc.org/github.com/go-resty/resty#Client.OnBeforeRequest) and [Response](https://godoc.org/github.com/go-resty/resty#Client.OnAfterResponse) middlewares
+  * resty client HTTP & REST [Request](https://godoc.org/gopkg.in/resty.v1#Client.OnBeforeRequest) and [Response](https://godoc.org/gopkg.in/resty.v1#Client.OnAfterResponse) middlewares
   * `Request.SetContext` supported `go1.7` and above
   * Authorization option of `BasicAuth` and `Bearer` token
   * Set request `ContentLength` value for all request or particular request
   * Choose between HTTP and REST mode. Default is `REST`
     * `HTTP` - default up to 10 redirects and no automatic response unmarshal
     * `REST` - defaults to no redirects and automatic response marshal/unmarshal for `JSON` & `XML`
-  * Custom [Root Certificates](https://godoc.org/github.com/go-resty/resty#Client.SetRootCertificate) and Client [Certificates](https://godoc.org/github.com/go-resty/resty#Client.SetCertificates)
-  * Download/Save HTTP response directly into File, like `curl -o` flag. See [SetOutputDirectory](https://godoc.org/github.com/go-resty/resty#Client.SetOutputDirectory) & [SetOutput](https://godoc.org/github.com/go-resty/resty#Request.SetOutput).
+  * Custom [Root Certificates](https://godoc.org/gopkg.in/resty.v1#Client.SetRootCertificate) and Client [Certificates](https://godoc.org/gopkg.in/resty.v1#Client.SetCertificates)
+  * Download/Save HTTP response directly into File, like `curl -o` flag. See [SetOutputDirectory](https://godoc.org/gopkg.in/resty.v1#Client.SetOutputDirectory) & [SetOutput](https://godoc.org/gopkg.in/resty.v1#Request.SetOutput).
   * Cookies for your request and CookieJar support
   * SRV Record based request instead of Host URL
   * Client settings like `Timeout`, `RedirectPolicy`, `Proxy`, `TLSClientConfig`, `Transport`, etc.
-  * Optionally allows GET request with payload, see [SetAllowGetMethodPayload](https://godoc.org/github.com/go-resty/resty#Client.SetAllowGetMethodPayload)
+  * Optionally allows GET request with payload, see [SetAllowGetMethodPayload](https://godoc.org/gopkg.in/resty.v1#Client.SetAllowGetMethodPayload)
   * Supports registering external JSON library into resty, see [how to use](https://github.com/go-resty/resty/issues/76#issuecomment-314015250)
   * Exposes Response reader without reading response (no auto-unmarshaling) if need be, see [how to use](https://github.com/go-resty/resty/issues/87#issuecomment-322100604)
   * Option to specify expected `Content-Type` when response `Content-Type` header missing. Refer to [#92](https://github.com/go-resty/resty/issues/92)
@@ -45,16 +59,20 @@ Resty first version released on Sep 15, 2015 then it grew gradually as a very ha
     * Have client level settings & options and also override at Request level if you want to
     * Request and Response middlewares
     * Create Multiple clients if you want to `resty.New()`
-    * Supports `http.RoundTripper` implementation, see [SetTransport](https://godoc.org/github.com/go-resty/resty#Client.SetTransport)
+    * Supports `http.RoundTripper` implementation, see [SetTransport](https://godoc.org/gopkg.in/resty.v1#Client.SetTransport)
     * goroutine concurrent safe
     * REST and HTTP modes
     * Debug mode - clean and informative logging presentation
-    * Gzip - I'm not doing anything here. Go does it automatically
+    * Gzip - Go does it automatically also resty has fallback handling too
+    * Works fine with `HTTP/2` and `HTTP/1.1`
+  * [Bazel support](#bazel-support)
+  * Easily mock resty for testing, [for e.g.](#mocking-http-requests-using-httpmock-library)
   * Well tested client library
 
-resty tested with Go `v1.3` and above.
+Resty works with `go1.3` and above.
 
-#### Included Batteries
+### Included Batteries
+
   * Redirect Policies - see [how to use](#redirect-policy)
     * NoRedirectPolicy
     * FlexibleRedirectPolicy
@@ -67,34 +85,47 @@ resty tested with Go `v1.3` and above.
   * etc (upcoming - throw your idea's [here](https://github.com/go-resty/resty/issues)).
 
 ## Installation
+
 #### Stable Version - Production Ready
+
 Please refer section [Versioning](#versioning) for detailed info.
-```sh
-# install the library
-go get -u gopkg.in/resty.v1
-```
-#### Latest Version - Development Edge
-```sh
-# install the latest & greatest library
-go get -u github.com/go-resty/resty
+
+##### go.mod
+
+```bash
+require gopkg.in/resty.v1 v1.12.0
 ```
 
-## It might interest you :)
+##### go get
+```bash
+go get -u gopkg.in/resty.v1
+```
+
+#### Heads up for upcoming Resty v2 
+
+Resty v2 release will be moving away from `gopkg.in` proxy versioning. It will completely follow and adpating Go Mod versioning recommendation. For e.g.: module definition would be `module github.com/go-resty/resty/v2`.
+
+
+## It might be beneficial for your project :smile:
 
 Resty author also published following projects for Go Community.
 
-  * [aah framework](https://aahframework.org) - A scalable, performant, rapid development - Web framework for Go.
+  * [aah framework](https://aahframework.org) - A secure, flexible, rapid Go web framework.
+  * [THUMBAI](https://thumbai.app), [Source Code](https://github.com/thumbai/thumbai) - Go Mod Repository, Go Vanity Service and Simple Proxy Server.
   * [go-model](https://github.com/jeevatkm/go-model) - Robust & Easy to use model mapper and utility methods for Go `struct`.
 
 ## Usage
+
 The following samples will assist you to become as comfortable as possible with resty library. Resty comes with ready to use DefaultClient.
 
 Import resty into your code and refer it as `resty`.
+
 ```go
 import "gopkg.in/resty.v1"
 ```
 
 #### Simple GET
+
 ```go
 // GET request
 resp, err := resty.R().Get("http://httpbin.org/get")
@@ -112,21 +143,24 @@ fmt.Printf("\nResponse Body: %v", resp)     // or resp.String() or string(resp.B
 Error: <nil>
 Response Status Code: 200
 Response Status: 200 OK
-Response Time: 644.290186ms
-Response Received At: 2015-09-15 12:05:28.922780103 -0700 PDT
+Response Time: 160.1151ms
+Response Received At: 2018-10-16 16:28:34.8595663 -0700 PDT m=+0.166119401
 Response Body: {
   "args": {},
   "headers": {
     "Accept-Encoding": "gzip",
+    "Connection": "close",
     "Host": "httpbin.org",
-    "User-Agent": "go-resty v0.1 - https://github.com/go-resty/resty"
+    "User-Agent": "go-resty/1.10.0 (https://github.com/go-resty/resty)"
   },
   "origin": "0.0.0.0",
   "url": "http://httpbin.org/get"
 }
 */
 ```
+
 #### Enhanced GET
+
 ```go
 resp, err := resty.R().
       SetQueryParams(map[string]string{
@@ -150,6 +184,7 @@ resp, err := resty.R().
 ```
 
 #### Various POST method combinations
+
 ```go
 // POST JSON string
 // No need to set content type, if you have client level setting
@@ -198,7 +233,9 @@ resp, err := resty.R().
 ```
 
 #### Sample PUT
+
 You can use various combinations of `PUT` method call like demonstrated for `POST`.
+
 ```go
 // Note: This is one sample of PUT method usage, refer POST for more combination
 
@@ -217,7 +254,9 @@ resp, err := resty.R().
 ```
 
 #### Sample PATCH
+
 You can use various combinations of `PATCH` method call like demonstrated for `POST`.
+
 ```go
 // Note: This is one sample of PUT method usage, refer POST for more combination
 
@@ -233,6 +272,7 @@ resp, err := resty.R().
 ```
 
 #### Sample DELETE, HEAD, OPTIONS
+
 ```go
 // DELETE a article
 // No need to set auth token, error, if you have client level settings
@@ -264,22 +304,25 @@ resp, err := resty.R().
 ```
 
 ### Multipart File(s) upload
+
 #### Using io.Reader
+
 ```go
 profileImgBytes, _ := ioutil.ReadFile("/Users/jeeva/test-img.png")
 notesBytes, _ := ioutil.ReadFile("/Users/jeeva/text-file.txt")
 
-resp, err := dclr().
+resp, err := resty.R().
       SetFileReader("profile_img", "test-img.png", bytes.NewReader(profileImgBytes)).
       SetFileReader("notes", "text-file.txt", bytes.NewReader(notesBytes)).
       SetFormData(map[string]string{
           "first_name": "Jeevanandam",
           "last_name": "M",
       }).
-      Post(t"http://myapp.com/upload")
+      Post("http://myapp.com/upload")
 ```
 
 #### Using File directly from Path
+
 ```go
 // Single file scenario
 resp, err := resty.R().
@@ -310,7 +353,8 @@ resp, err := resty.R().
       Post("http://myapp.com/profile")
 ```
 
-#### Sample Form submision
+#### Sample Form submission
+
 ```go
 // just mentioning about POST as an example with simple flow
 // User Login
@@ -341,6 +385,7 @@ resp, err := resty.R().
 ```
 
 #### Save HTTP Response into File
+
 ```go
 // Setting output directory path, If directory not exists then resty creates one!
 // This is optional one, if you're planning using absoule path in
@@ -359,8 +404,25 @@ _, err := resty.R().
           Get("http://bit.ly/1LouEKr")
 ```
 
+#### Request URL Path Params
+
+Resty provides easy to use dynamic request URL path params. Params can be set at client and request level. Client level params value can be overridden at request level.
+
+```go
+resty.R().SetPathParams(map[string]string{
+   "userId": "sample@sample.com",
+   "subAccountId": "100002",
+}).
+Get("/v1/users/{userId}/{subAccountId}/details")
+
+// Result:
+//   Composed URL - /v1/users/sample@sample.com/100002/details
+```
+
 #### Request and Response Middleware
+
 Resty provides middleware ability to manipulate for Request and Response. It is more flexible than callback approach.
+
 ```go
 // Registering Request Middleware
 resty.OnBeforeRequest(func(c *resty.Client, req *resty.Request) error {
@@ -380,7 +442,9 @@ resty.OnAfterResponse(func(c *resty.Client, resp *resty.Response) error {
 ```
 
 #### Redirect Policy
+
 Resty provides few ready to use redirect policy(s) also it supports multiple policies together.
+
 ```go
 // Assign Client Redirect Policy. Create one as per you need
 resty.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
@@ -391,7 +455,9 @@ resty.SetRedirectPolicy(resty.FlexibleRedirectPolicy(20),
 ```
 
 ##### Custom Redirect Policy
+
 Implement [RedirectPolicy](redirect.go#L20) interface and register it with resty client. Have a look [redirect.go](redirect.go) for more information.
+
 ```go
 // Using raw func into resty.SetRedirectPolicy
 resty.SetRedirectPolicy(resty.RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
@@ -419,7 +485,8 @@ func (c *CustomRedirectPolicy) Apply(req *http.Request, via []*http.Request) err
 resty.SetRedirectPolicy(CustomRedirectPolicy{/* initialize variables */})
 ```
 
-#### Custom Root Certificates and Client Certifcates
+#### Custom Root Certificates and Client Certificates
+
 ```go
 // Custom Root certificates, just supply .pem file.
 // you can add one or more root certificates, its get appended
@@ -441,23 +508,18 @@ resty.SetCertificates(cert1, cert2, cert3)
 ```
 
 #### Proxy Settings - Client as well as at Request Level
+
 Default `Go` supports Proxy via environment variable `HTTP_PROXY`. Resty provides support via `SetProxy` & `RemoveProxy`.
 Choose as per your need.
 
 **Client Level Proxy** settings applied to all the request
+
 ```go
 // Setting a Proxy URL and Port
 resty.SetProxy("http://proxyserver:8888")
 
 // Want to remove proxy setting
 resty.RemoveProxy()
-```
-**Request Level Proxy** settings, gives control to override at individal request level
-```go
-// Set proxy for current request
-resp, err := c.R().
-    SetProxy("http://sampleproxy:8888").
-    Get("http://httpbin.org/get")
 ```
 
 #### Retries
@@ -466,9 +528,10 @@ Resty uses [backoff](http://www.awsarchitectureblog.com/2015/03/backoff.html)
 to increase retry intervals after each attempt.
 
 Usage example:
+
 ```go
 // Retries are configured per client
-resty.DefaultClient.
+resty.
     // Set retry count to non zero to enable retries
     SetRetryCount(3).
     // You can override initial retry wait time.
@@ -485,15 +548,14 @@ Above setup will result in resty retrying requests returned non nil error up to
 You can optionally provide client with custom retry conditions:
 
 ```go
-resty.DefaultClient.
-    AddRetryCondition(
-        // Condition function will be provided with *resty.Response as a
-        // parameter. It is expected to return (bool, error) pair. Resty will retry
-        // in case condition returns true or non nil error.
-        func(r *resty.Response) (bool, error) {
-            return r.StatusCode() == http.StatusTooManyRequests, nil
-        }
-    )
+resty.AddRetryCondition(
+    // Condition function will be provided with *resty.Response as a
+    // parameter. It is expected to return (bool, error) pair. Resty will retry
+    // in case condition returns true or non nil error.
+    func(r *resty.Response) (bool, error) {
+        return r.StatusCode() == http.StatusTooManyRequests, nil
+    },
+)
 ```
 
 Above example will make resty retry requests ended with `429 Too Many Requests`
@@ -505,6 +567,7 @@ It is also possible to use `resty.Backoff(...)` to get arbitrary retry scenarios
 implemented. [Reference](retry_test.go).
 
 #### Choose REST or HTTP mode
+
 ```go
 // REST mode. This is Default.
 resty.SetRESTMode()
@@ -514,12 +577,14 @@ resty.SetHTTPMode()
 ```
 
 #### Allow GET request with Payload
+
 ```go
 // Allow GET request with Payload. This is disabled by default.
 resty.SetAllowGetMethodPayload(true)
 ```
 
 #### Wanna Multiple Clients
+
 ```go
 // Here you go!
 // Client 1
@@ -529,13 +594,14 @@ client1.R().Get("http://httpbin.org")
 
 // Client 2
 client2 := resty.New()
-client1.R().Head("http://httpbin.org")
+client2.R().Head("http://httpbin.org")
 // ...
 
 // Bend it as per your need!!!
 ```
 
 #### Remaining Client Settings & its Options
+
 ```go
 // Unique settings at Client level
 //--------------------------------
@@ -554,7 +620,7 @@ resty.SetTLSClientConfig(&tls.Config{ RootCAs: roots })
 resty.SetTLSClientConfig(&tls.Config{ InsecureSkipVerify: true })
 
 // Set client timeout as per your need
-resty.SetTimeout(time.Duration(1 * time.Minute))
+resty.SetTimeout(1 * time.Minute)
 
 
 // You can override all below settings and options at request level if you want to
@@ -625,24 +691,51 @@ r := resty.New().SetTransport(&transport).SetScheme("http").SetHostURL(unixSocke
 
 // No need to write the host's URL on the request, just the path.
 r.R().Get("/index.html")
-
 ```
 
+#### Bazel support
+
+Resty can be built, tested and depended upon via [Bazel](https://bazel.build).
+For example, to run all tests:
+
+```shell
+bazel test :go_default_test
+```
+
+#### Mocking http requests using [httpmock](https://github.com/jarcoal/httpmock) library
+
+In order to mock the http requests when testing your application you
+could use the `httpmock` library.
+
+When using the default resty client, you should pass the client to the library as follow:
+
+```go
+httpmock.ActivateNonDefault(resty.DefaultClient.GetClient())
+```
+
+More detailed example of mocking resty http requests using ginko could be found [here](https://github.com/jarcoal/httpmock#ginkgo--resty-example).
+
 ## Versioning
+
 resty releases versions according to [Semantic Versioning](http://semver.org)
 
-`gopkg.in/resty.vX` points to appropriate tag versions; `X` denotes version number and it's a stable release. It's recommended to use version, for eg. `gopkg.in/resty.v0`. Development takes place at the master branch. Although the code in master should always compile and test successfully, it might break API's. We aim to maintain backwards compatibility, but API's and behaviour might be changed to fix a bug.
+  * `gopkg.in/resty.vX` points to appropriate tagged versions; `X` denotes version series number and it's a stable release for production use. For e.g. `gopkg.in/resty.v0`.
+  * Development takes place at the master branch. Although the code in master should always compile and test successfully, it might break API's. I aim to maintain backwards compatibility, but sometimes API's and behavior might be changed to fix a bug.
 
-## Contributing
-Welcome! If you find any improvement or issue you want to fix, feel free to send a pull request, I like pull requests that include test cases for fix/enhancement. I have done my best to bring pretty good code coverage. Feel free to write tests.
+## Contribution
+
+I would welcome your contribution! If you find any improvement or issue you want to fix, feel free to send a pull request, I like pull requests that include test cases for fix/enhancement. I have done my best to bring pretty good code coverage. Feel free to write tests.
 
 BTW, I'd like to know what you think about `Resty`. Kindly open an issue or send me an email; it'd mean a lot to me.
 
-## Author
+## Creator
+
 [Jeevanandam M.](https://github.com/jeevatkm) (jeeva@myjeeva.com)
 
 ## Contributors
+
 Have a look on [Contributors](https://github.com/go-resty/resty/graphs/contributors) page.
 
 ## License
+
 Resty released under MIT license, refer [LICENSE](LICENSE) file.

--- a/vendor/gopkg.in/resty.v1/WORKSPACE
+++ b/vendor/gopkg.in/resty.v1/WORKSPACE
@@ -1,0 +1,27 @@
+workspace(name = "resty")
+
+git_repository(
+    name = "io_bazel_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.13.0",
+)
+
+git_repository(
+    name = "bazel_gazelle",
+    remote = "https://github.com/bazelbuild/bazel-gazelle.git",
+    tag = "0.13.0",
+)
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_rules_dependencies",
+    "go_register_toolchains",
+)
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()

--- a/vendor/gopkg.in/resty.v1/default.go
+++ b/vendor/gopkg.in/resty.v1/default.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -20,55 +21,15 @@ import (
 // DefaultClient of resty
 var DefaultClient *Client
 
-// New method creates a new go-resty client
+// New method creates a new go-resty client.
 func New() *Client {
 	cookieJar, _ := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	return createClient(&http.Client{Jar: cookieJar})
+}
 
-	c := &Client{
-		HostURL:          "",
-		QueryParam:       url.Values{},
-		FormData:         url.Values{},
-		Header:           http.Header{},
-		UserInfo:         nil,
-		Token:            "",
-		Cookies:          make([]*http.Cookie, 0),
-		Debug:            false,
-		Log:              getLogger(os.Stderr),
-		RetryCount:       0,
-		RetryWaitTime:    defaultWaitTime,
-		RetryMaxWaitTime: defaultMaxWaitTime,
-		JSONMarshal:      json.Marshal,
-		JSONUnmarshal:    json.Unmarshal,
-		httpClient:       &http.Client{Jar: cookieJar},
-	}
-
-	// Default transport
-	c.SetTransport(&http.Transport{})
-
-	// Default redirect policy
-	c.SetRedirectPolicy(NoRedirectPolicy())
-
-	// default before request middlewares
-	c.beforeRequest = []func(*Client, *Request) error{
-		parseRequestURL,
-		parseRequestHeader,
-		parseRequestBody,
-		createHTTPRequest,
-		addCredentials,
-		requestLogger,
-	}
-
-	// user defined request middlewares
-	c.udBeforeRequest = []func(*Client, *Request) error{}
-
-	// default after response middlewares
-	c.afterResponse = []func(*Client, *Response) error{
-		responseLogger,
-		parseResponseBody,
-		saveResponseIntoFile,
-	}
-
-	return c
+// NewWithClient method create a new go-resty client with given `http.Client`.
+func NewWithClient(hc *http.Client) *Client {
+	return createClient(hc)
 }
 
 // R creates a new resty request object, it is used form a HTTP/RESTful request
@@ -156,6 +117,11 @@ func SetPreRequestHook(h func(*Client, *Request) error) *Client {
 // SetDebug method enables the debug mode. See `Client.SetDebug` for more information.
 func SetDebug(d bool) *Client {
 	return DefaultClient.SetDebug(d)
+}
+
+// SetDebugBodyLimit method sets the response body limit for debug mode. See `Client.SetDebugBodyLimit` for more information.
+func SetDebugBodyLimit(sl int64) *Client {
+	return DefaultClient.SetDebugBodyLimit(sl)
 }
 
 // SetAllowGetMethodPayload method allows the GET method with payload. See `Client.SetAllowGetMethodPayload` for more information.
@@ -285,10 +251,75 @@ func SetDoNotParseResponse(parse bool) *Client {
 	return DefaultClient.SetDoNotParseResponse(parse)
 }
 
+// SetPathParams method sets the Request path parameter key-value pairs. See
+// `Client.SetPathParams` for more information.
+func SetPathParams(params map[string]string) *Client {
+	return DefaultClient.SetPathParams(params)
+}
+
 // IsProxySet method returns the true if proxy is set on client otherwise false.
 // See `Client.IsProxySet` for more information.
 func IsProxySet() bool {
 	return DefaultClient.IsProxySet()
+}
+
+// GetClient method returns the current `http.Client` used by the default resty client.
+func GetClient() *http.Client {
+	return DefaultClient.httpClient
+}
+
+//‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+// Unexported methods
+//___________________________________
+
+func createClient(hc *http.Client) *Client {
+	c := &Client{
+		HostURL:            "",
+		QueryParam:         url.Values{},
+		FormData:           url.Values{},
+		Header:             http.Header{},
+		UserInfo:           nil,
+		Token:              "",
+		Cookies:            make([]*http.Cookie, 0),
+		Debug:              false,
+		Log:                getLogger(os.Stderr),
+		RetryCount:         0,
+		RetryWaitTime:      defaultWaitTime,
+		RetryMaxWaitTime:   defaultMaxWaitTime,
+		JSONMarshal:        json.Marshal,
+		JSONUnmarshal:      json.Unmarshal,
+		jsonEscapeHTML:     true,
+		httpClient:         hc,
+		debugBodySizeLimit: math.MaxInt32,
+		pathParams:         make(map[string]string),
+	}
+
+	// Log Prefix
+	c.SetLogPrefix("RESTY ")
+
+	// Default redirect policy
+	c.SetRedirectPolicy(NoRedirectPolicy())
+
+	// default before request middlewares
+	c.beforeRequest = []func(*Client, *Request) error{
+		parseRequestURL,
+		parseRequestHeader,
+		parseRequestBody,
+		createHTTPRequest,
+		addCredentials,
+	}
+
+	// user defined request middlewares
+	c.udBeforeRequest = []func(*Client, *Request) error{}
+
+	// default after response middlewares
+	c.afterResponse = []func(*Client, *Response) error{
+		responseLogger,
+		parseResponseBody,
+		saveResponseIntoFile,
+	}
+
+	return c
 }
 
 func init() {

--- a/vendor/gopkg.in/resty.v1/go.mod
+++ b/vendor/gopkg.in/resty.v1/go.mod
@@ -1,0 +1,3 @@
+module gopkg.in/resty.v1
+
+require golang.org/x/net v0.0.0-20181220203305-927f97764cc3

--- a/vendor/gopkg.in/resty.v1/redirect.go
+++ b/vendor/gopkg.in/resty.v1/redirect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -36,7 +36,7 @@ func (f RedirectPolicyFunc) Apply(req *http.Request, via []*http.Request) error 
 // 		resty.SetRedirectPolicy(NoRedirectPolicy())
 func NoRedirectPolicy() RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
-		return errors.New("Auto redirect is disabled")
+		return errors.New("auto redirect is disabled")
 	})
 }
 
@@ -45,7 +45,7 @@ func NoRedirectPolicy() RedirectPolicy {
 func FlexibleRedirectPolicy(noOfRedirect int) RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		if len(via) >= noOfRedirect {
-			return fmt.Errorf("Stopped after %d redirects", noOfRedirect)
+			return fmt.Errorf("stopped after %d redirects", noOfRedirect)
 		}
 
 		checkHostAndAddHeaders(req, via[0])
@@ -65,7 +65,7 @@ func DomainCheckRedirectPolicy(hostnames ...string) RedirectPolicy {
 
 	fn := RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		if ok := hosts[getHostname(req.URL.Host)]; !ok {
-			return errors.New("Redirect is not allowed as per DomainCheckRedirectPolicy")
+			return errors.New("redirect is not allowed as per DomainCheckRedirectPolicy")
 		}
 
 		return nil
@@ -83,7 +83,7 @@ func getHostname(host string) (hostname string) {
 }
 
 // By default Golang will not redirect request headers
-// after go throughing various discussion commments from thread
+// after go throughing various discussion comments from thread
 // https://github.com/golang/go/issues/4800
 // go-resty will add all the headers during a redirect for the same host
 func checkHostAndAddHeaders(cur *http.Request, pre *http.Request) {

--- a/vendor/gopkg.in/resty.v1/request16.go
+++ b/vendor/gopkg.in/resty.v1/request16.go
@@ -1,6 +1,6 @@
 // +build !go1.7
 
-// Copyright (c) 2015-2016 Jeevanandam M (jeeva@myjeeva.com)
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com)
 // 2016 Andrew Grigorev (https://github.com/ei-grad)
 // All rights reserved.
 // resty source code and usage is governed by a MIT style
@@ -10,6 +10,7 @@ package resty
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
@@ -17,34 +18,36 @@ import (
 
 // Request type is used to compose and send individual request from client
 // go-resty is provide option override client level settings such as
-//		Auth Token, Basic Auth credentials, Header, Query Param, Form Data, Error object
+// Auth Token, Basic Auth credentials, Header, Query Param, Form Data, Error object
 // and also you can add more options for that particular request
-//
 type Request struct {
 	URL        string
 	Method     string
+	Token      string
 	QueryParam url.Values
 	FormData   url.Values
 	Header     http.Header
-	UserInfo   *User
-	Token      string
+	Time       time.Time
 	Body       interface{}
 	Result     interface{}
 	Error      interface{}
-	Time       time.Time
 	RawRequest *http.Request
 	SRV        *SRVRecord
+	UserInfo   *User
 
-	client              *Client
-	bodyBuf             *bytes.Buffer
 	isMultiPart         bool
 	isFormData          bool
 	setContentLength    bool
 	isSaveResponse      bool
-	outputFile          string
-	multipartFiles      []*File
 	notParseResponse    bool
+	jsonEscapeHTML      bool
+	outputFile          string
 	fallbackContentType string
+	pathParams          map[string]string
+	client              *Client
+	bodyBuf             *bytes.Buffer
+	multipartFiles      []*File
+	multipartFields     []*MultipartField
 }
 
 func (r *Request) addContextIfAvailable() {
@@ -55,3 +58,6 @@ func (r *Request) isContextCancelledIfAvailable() bool {
 	// just always return false golang<1.7
 	return false
 }
+
+// for !go1.7
+var noescapeJSONMarshal = json.Marshal

--- a/vendor/gopkg.in/resty.v1/request17.go
+++ b/vendor/gopkg.in/resty.v1/request17.go
@@ -1,6 +1,6 @@
 // +build go1.7 go1.8
 
-// Copyright (c) 2015-2016 Jeevanandam M (jeeva@myjeeva.com)
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com)
 // 2016 Andrew Grigorev (https://github.com/ei-grad)
 // All rights reserved.
 // resty source code and usage is governed by a MIT style
@@ -11,6 +11,7 @@ package resty
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,35 +19,46 @@ import (
 
 // Request type is used to compose and send individual request from client
 // go-resty is provide option override client level settings such as
-//		Auth Token, Basic Auth credentials, Header, Query Param, Form Data, Error object
+// Auth Token, Basic Auth credentials, Header, Query Param, Form Data, Error object
 // and also you can add more options for that particular request
-//
 type Request struct {
 	URL        string
 	Method     string
+	Token      string
 	QueryParam url.Values
 	FormData   url.Values
 	Header     http.Header
-	UserInfo   *User
-	Token      string
+	Time       time.Time
 	Body       interface{}
 	Result     interface{}
 	Error      interface{}
-	Time       time.Time
 	RawRequest *http.Request
 	SRV        *SRVRecord
+	UserInfo   *User
 
-	client              *Client
-	bodyBuf             *bytes.Buffer
 	isMultiPart         bool
 	isFormData          bool
 	setContentLength    bool
 	isSaveResponse      bool
-	outputFile          string
-	multipartFiles      []*File
 	notParseResponse    bool
-	ctx                 context.Context
+	jsonEscapeHTML      bool
+	outputFile          string
 	fallbackContentType string
+	ctx                 context.Context
+	pathParams          map[string]string
+	client              *Client
+	bodyBuf             *bytes.Buffer
+	multipartFiles      []*File
+	multipartFields     []*MultipartField
+}
+
+// Context method returns the Context if its already set in request
+// otherwise it creates new one using `context.Background()`.
+func (r *Request) Context() context.Context {
+	if r.ctx == nil {
+		return context.Background()
+	}
+	return r.ctx
 }
 
 // SetContext method sets the context.Context for current Request. It allows
@@ -71,4 +83,14 @@ func (r *Request) isContextCancelledIfAvailable() bool {
 		}
 	}
 	return false
+}
+
+// for go1.7+
+var noescapeJSONMarshal = func(v interface{}) ([]byte, error) {
+	buf := acquireBuffer()
+	defer releaseBuffer(buf)
+	encoder := json.NewEncoder(buf)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v)
+	return buf.Bytes(), err
 }

--- a/vendor/gopkg.in/resty.v1/response.go
+++ b/vendor/gopkg.in/resty.v1/response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package resty
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -119,20 +120,31 @@ func (r *Response) RawBody() io.ReadCloser {
 	return r.RawResponse.Body
 }
 
-func (r *Response) fmtBodyString() string {
-	bodyStr := "***** NO CONTENT *****"
+// IsSuccess method returns true if HTTP status code >= 200 and <= 299 otherwise false.
+func (r *Response) IsSuccess() bool {
+	return r.StatusCode() > 199 && r.StatusCode() < 300
+}
+
+// IsError method returns true if HTTP status code >= 400 otherwise false.
+func (r *Response) IsError() bool {
+	return r.StatusCode() > 399
+}
+
+func (r *Response) fmtBodyString(sl int64) string {
 	if r.body != nil {
+		if int64(len(r.body)) > sl {
+			return fmt.Sprintf("***** RESPONSE TOO LARGE (size - %d) *****", len(r.body))
+		}
 		ct := r.Header().Get(hdrContentTypeKey)
 		if IsJSONType(ct) {
 			out := acquireBuffer()
 			defer releaseBuffer(out)
 			if err := json.Indent(out, r.body, "", "   "); err == nil {
-				bodyStr = string(out.Bytes())
+				return out.String()
 			}
-		} else {
-			bodyStr = r.String()
 		}
+		return r.String()
 	}
 
-	return bodyStr
+	return "***** NO CONTENT *****"
 }

--- a/vendor/gopkg.in/resty.v1/resty.go
+++ b/vendor/gopkg.in/resty.v1/resty.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+// Package resty provides Simple HTTP and REST client library for Go.
+package resty
+
+// Version # of resty
+const Version = "1.12.0"

--- a/vendor/gopkg.in/resty.v1/retry.go
+++ b/vendor/gopkg.in/resty.v1/retry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -102,7 +102,11 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 		// See the following article...
 		// http://www.awsarchitectureblog.com/2015/03/backoff.html
 		temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
-		sleepDuration := time.Duration(int(temp/2) + rand.Intn(int(temp/2)))
+		ri := int(temp / 2)
+		if ri <= 0 {
+			ri = 1<<31 - 1 // max int for arch 386
+		}
+		sleepDuration := time.Duration(math.Abs(float64(ri + rand.Intn(ri))))
 
 		if sleepDuration < opts.waitTime {
 			sleepDuration = opts.waitTime

--- a/vendor/gopkg.in/resty.v1/util.go
+++ b/vendor/gopkg.in/resty.v1/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -8,14 +8,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"log"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -25,7 +28,7 @@ import (
 
 // IsStringEmpty method tells whether given string is empty or not
 func IsStringEmpty(str string) bool {
-	return (len(strings.TrimSpace(str)) == 0)
+	return len(strings.TrimSpace(str)) == 0
 }
 
 // DetectContentType method is used to figure out `Request.Body` content type for request header
@@ -82,8 +85,38 @@ func Unmarshalc(c *Client, ct string, b []byte, d interface{}) (err error) {
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+// RequestLog and ResponseLog type
+//___________________________________
+
+// RequestLog struct is used to collected information from resty request
+// instance for debug logging. It sent to request log callback before resty
+// actually logs the information.
+type RequestLog struct {
+	Header http.Header
+	Body   string
+}
+
+// ResponseLog struct is used to collected information from resty response
+// instance for debug logging. It sent to response log callback before resty
+// actually logs the information.
+type ResponseLog struct {
+	Header http.Header
+	Body   string
+}
+
+//‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // Package Unexported methods
 //___________________________________
+
+// way to disable the HTML escape as opt-in
+func jsonMarshal(c *Client, r *Request, d interface{}) ([]byte, error) {
+	if !r.jsonEscapeHTML {
+		return noescapeJSONMarshal(d)
+	} else if !c.jsonEscapeHTML {
+		return noescapeJSONMarshal(d)
+	}
+	return c.JSONMarshal(d)
+}
 
 func firstNonEmpty(v ...string) string {
 	for _, s := range v {
@@ -98,32 +131,62 @@ func getLogger(w io.Writer) *log.Logger {
 	return log.New(w, "RESTY ", log.LstdFlags)
 }
 
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+func escapeQuotes(s string) string {
+	return quoteEscaper.Replace(s)
+}
+
+func createMultipartHeader(param, fileName, contentType string) textproto.MIMEHeader {
+	hdr := make(textproto.MIMEHeader)
+	hdr.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
+		escapeQuotes(param), escapeQuotes(fileName)))
+	hdr.Set("Content-Type", contentType)
+	return hdr
+}
+
+func addMultipartFormField(w *multipart.Writer, mf *MultipartField) error {
+	partWriter, err := w.CreatePart(createMultipartHeader(mf.Param, mf.FileName, mf.ContentType))
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(partWriter, mf.Reader)
+	return err
+}
+
+func writeMultipartFormFile(w *multipart.Writer, fieldName, fileName string, r io.Reader) error {
+	// Auto detect actual multipart content type
+	cbuf := make([]byte, 512)
+	size, err := r.Read(cbuf)
+	if err != nil {
+		return err
+	}
+
+	partWriter, err := w.CreatePart(createMultipartHeader(fieldName, fileName, http.DetectContentType(cbuf)))
+	if err != nil {
+		return err
+	}
+
+	if _, err = partWriter.Write(cbuf[:size]); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(partWriter, r)
+	return err
+}
+
 func addFile(w *multipart.Writer, fieldName, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(part, file)
-
-	return err
+	defer closeq(file)
+	return writeMultipartFormFile(w, fieldName, filepath.Base(path), file)
 }
 
 func addFileReader(w *multipart.Writer, f *File) error {
-	part, err := w.CreateFormFile(f.ParamName, f.Name)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(part, f.Reader)
-
-	return err
+	return writeMultipartFormFile(w, f.ParamName, f.Name, f.Reader)
 }
 
 func getPointer(v interface{}) interface{} {
@@ -135,7 +198,7 @@ func getPointer(v interface{}) interface{} {
 }
 
 func isPayloadSupported(m string, allowMethodGet bool) bool {
-	return (m == MethodPost || m == MethodPut || m == MethodDelete || m == MethodPatch || (allowMethodGet && m == MethodGet))
+	return !(m == MethodHead || m == MethodOptions || (m == MethodGet && !allowMethodGet))
 }
 
 func typeOf(i interface{}) reflect.Type {
@@ -166,7 +229,7 @@ func createDirectory(dir string) (err error) {
 }
 
 func canJSONMarshal(contentType string, kind reflect.Kind) bool {
-	return IsJSONType(contentType) && (kind == reflect.Struct || kind == reflect.Map)
+	return IsJSONType(contentType) && (kind == reflect.Struct || kind == reflect.Map || kind == reflect.Slice)
 }
 
 func functionName(i interface{}) string {
@@ -182,4 +245,37 @@ func releaseBuffer(buf *bytes.Buffer) {
 		buf.Reset()
 		bufPool.Put(buf)
 	}
+}
+
+func closeq(v interface{}) {
+	if c, ok := v.(io.Closer); ok {
+		sliently(c.Close())
+	}
+}
+
+func sliently(_ ...interface{}) {}
+
+func composeHeaders(hdrs http.Header) string {
+	var str []string
+	for _, k := range sortHeaderKeys(hdrs) {
+		str = append(str, fmt.Sprintf("%25s: %s", k, strings.Join(hdrs[k], ", ")))
+	}
+	return strings.Join(str, "\n")
+}
+
+func sortHeaderKeys(hdrs http.Header) []string {
+	var keys []string
+	for key := range hdrs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func copyHeaders(hdrs http.Header) http.Header {
+	nh := http.Header{}
+	for k, v := range hdrs {
+		nh[k] = v
+	}
+	return nh
 }


### PR DESCRIPTION
The proper module/import name for v1 of this package is gopkg.in/resty.v1 as defined here

If we move to Go Modules in future - this'll blow up due to the package resolving a different URL than the module name.

Unblocks https://github.com/giantswarm/clusterclient/pull/79